### PR TITLE
Bugfix/43 同じ年度の重複登録を修正

### DIFF
--- a/app/models/branch_fiscal_year_stat.rb
+++ b/app/models/branch_fiscal_year_stat.rb
@@ -2,7 +2,7 @@ class BranchFiscalYearStat < ApplicationRecord
   belongs_to :branch
   belongs_to :updater, class_name: "User", foreign_key: "user_id"
 
-  validates :fiscal_year, presence: true, length: { is: 4 }
+  validates :fiscal_year, presence: true, length: { is: 4 }, uniqueness: { scope: :branch_id }
   validates :annual_working_days, presence: true, numericality: { less_than_or_equal_to: 365 }
   validates :annual_employee_count, presence: true
 

--- a/app/models/co2_emission_factor.rb
+++ b/app/models/co2_emission_factor.rb
@@ -1,5 +1,5 @@
 class Co2EmissionFactor < ApplicationRecord
-  validates :fiscal_year, presence: true, length: { is: 4 }
+  validates :fiscal_year, presence: true, length: { is: 4 }, uniqueness: { scope: [ :workplace_type, :city_category ] }
   validates :workplace_type, presence: true
   validates :city_category, presence: true
   validates :co2_emission_factor, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,6 @@ module Co2meter
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.{rb,yml}")]
 
     config.time_zone = "Asia/Tokyo"
+    config.active_model.i18n_customize_full_message = true
   end
 end

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -47,6 +47,16 @@ ja:
           attributes:
             postcode:
               invalid: は半角数字7桁で入力してください
+        co2_emission_factor:
+          attributes:
+            fiscal_year:
+              format: "%{message}"
+              taken: この年度はすでに排出係数が登録されています。勤務形態と都市区分が同じ組み合わせは、1年度につき1つだけ登録できます
+        branch_fiscal_year_stat:
+          attributes:
+            fiscal_year:
+              format: "%{message}"
+              taken: この支店ではすでに同じ年度のデータが登録されています。同じ支店では、1年度に1つだけ登録できます
 
   layouts:
     application:

--- a/db/migrate/20250415053853_add_index_fiscal_year_to_branch_fiscal_year_stats.rb
+++ b/db/migrate/20250415053853_add_index_fiscal_year_to_branch_fiscal_year_stats.rb
@@ -1,0 +1,5 @@
+class AddIndexFiscalYearToBranchFiscalYearStats < ActiveRecord::Migration[7.2]
+  def change
+    add_index :branch_fiscal_year_stats, [ :fiscal_year, :branch_id ], unique: true
+  end
+end

--- a/db/migrate/20250415054712_add_index_fiscal_year_to_co2_emission_factors.rb
+++ b/db/migrate/20250415054712_add_index_fiscal_year_to_co2_emission_factors.rb
@@ -1,0 +1,5 @@
+class AddIndexFiscalYearToCo2EmissionFactors < ActiveRecord::Migration[7.2]
+  def change
+    add_index :co2_emission_factors, [ :fiscal_year, :workplace_type, :city_category ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_02_030202) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_15_054712) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,6 +23,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_02_030202) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["branch_id"], name: "index_branch_fiscal_year_stats_on_branch_id"
+    t.index ["fiscal_year", "branch_id"], name: "index_branch_fiscal_year_stats_on_fiscal_year_and_branch_id", unique: true
     t.index ["user_id"], name: "index_branch_fiscal_year_stats_on_user_id"
   end
 
@@ -49,6 +50,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_02_030202) do
     t.string "co2_emission_factor_unit", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["fiscal_year", "workplace_type", "city_category"], name: "idx_on_fiscal_year_workplace_type_city_category_9fdbed3fe5", unique: true
   end
 
   create_table "companies", force: :cascade do |t|


### PR DESCRIPTION
#43 
排出係数及び支店実績について、年度データの重複登録ができていたため、バリデーションとデータベースの一意性制約を追加